### PR TITLE
MAINT: point URLs to the scipy org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,5 +70,5 @@ so it's more important to have a descriptive than a catchy name!
 What if I think that one of the pinnings is wrong or out of date?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Please feel free to `open an issue <https://github.com/astrofrog/oldest-supported-numpy/issues/new>`_
+Please feel free to `open an issue <https://github.com/scipy/oldest-supported-numpy/issues/new>`_
 or a pull request if you think something is wrong or could be improved!

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,7 +5,7 @@ long_description = file: README.rst
 author = Thomas Robitaille
 author_email = thomas.robitaille@gmail.com
 license = BSD
-url = https://github.com/astrofrog/oldest-supported-numpy
+url = https://github.com/scipy/oldest-supported-numpy
 version = 0.2
 
 # The Numpy pinnings below have been adapted from those in the


### PR DESCRIPTION
Change URLs to point to the scipy org, now that the repo lives here.