### PR TITLE
Avoid duplication for recent Python versions and add Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,8 @@ jobs:
         - 3.7
         - 3.8
         - 3.9
-        - 3.10.0-alpha - 3.10.0
+        # Uncomment once Numpy builds fine with Python 3.10
+        # - 3.10.0-alpha - 3.10.0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
         - 3.5

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
+        python-version:
+        - 3.5
+        - 3.6
+        - 3.7
+        - 3.8
+        - 3.9
+        - 3.10.0-alpha - 3.10.0
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,9 @@ install_requires =
     numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
     numpy==1.17.3; python_version=='3.8'
+    numpy==1.19.3; python_version>='3.9'
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    numpy; python_version>='3.9'
+    numpy; python_version>='3.10'


### PR DESCRIPTION
**DO NOT MERGE!**

This is in preparation of Python 3.9 being released as discussed in #8. We shouldn't merge until it is confirmed that 1.19.3 is the first version of Numpy with wheels for Python 3.9.