### PR TITLE
Add unpinned Numpy for unsupported/future Python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,6 @@ jobs:
       if: matrix.python-version == '3.5'
       run: python -m pip install wheel
     - name: Install oldest-supported-numpy
-      run: python -m pip install .
+      run: python -m pip install -v .
     - name: Check that numpy was installed
       run: python -c 'import numpy'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,10 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install package
+    - name: Install wheel
+      if: matrix.python-version == '3.5'
+      run: python -m pip install wheel
+    - name: Install oldest-supported-numpy
       run: python -m pip install .
     - name: Check that numpy was installed
       run: python -c 'import numpy'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,8 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Upgrade pip and setuptools
+      run: python -m pip install pip setuptools --upgrade
     - name: Install wheel
       if: matrix.python-version == '3.5'
       run: python -m pip install wheel

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,11 +21,10 @@ install_requires =
     numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'
     numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'
     numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'
-    numpy==1.17.3; python_version=='3.8' and platform_system!='AIX'
     numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
-    numpy==1.17.3; python_version=='3.8' and platform_system=='AIX'
+    numpy==1.17.3; python_version=='3.8'
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions
     # to be used and allows wheels to be used as soon as they

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,8 +21,13 @@ install_requires =
     numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'
     numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'
     numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'
-    numpy==1.17.3; python_version>='3.8' and platform_system!='AIX'
+    numpy==1.17.3; python_version=='3.8' and platform_system!='AIX'
     numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
-    numpy==1.17.3; python_version>='3.8' and platform_system=='AIX'
+    numpy==1.17.3; python_version=='3.8' and platform_system=='AIX'
+    # For Python versions which aren't yet officially supported,
+    # we specify an unpinned Numpy which allows source distributions
+    # to be used and allows wheels to be used as soon as they
+    # become available.
+    numpy; python_version>='3.9'


### PR DESCRIPTION
Since there isn't yet a version of Numpy with wheels for Python 3.9 (and certainly not 3.10) I thought it would probably make sense in general to use an unpinned (and therefore latest available) version of Numpy as opposed to using the one for Python 3.8.