### PR TITLE
Add constraints for aarch64: numpy==1.19.0 for Python<=3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,30 @@ version = 0.6
 [options]
 python_requires = >=3.5
 install_requires =
-    numpy==1.13.3; python_version=='3.5' and platform_system!='AIX'
-    numpy==1.13.3; python_version=='3.6' and platform_system!='AIX'
-    numpy==1.14.5; python_version=='3.7' and platform_system!='AIX'
+    # NOTE: platform_system 'AIX' and platform_machine 'aarch64' are mutually
+    #       exclusive so they are specified by themself when setting their
+    #       numpy version.
+
+    # AIX requires fixes contained in numpy 1.16
     numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
-    numpy==1.17.3; python_version=='3.8'
+
+    # numpy 1.19 was the first minor release to provide aarch64 wheels, but
+    # wheels require fixes contained in numpy 1.19.2 (For Python 3.5: support
+    # was dropped in 1.19 so numpy 1.18.5 can be built from source instead).
+    numpy==1.18.5; python_version=='3.5' and platform_machine=='aarch64'
+    numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64'
+    numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'
+    numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'
+
+    # default numpy requirements
+    numpy==1.13.3; python_version=='3.5' and platform_machine!='aarch64' and platform_system!='AIX'
+    numpy==1.13.3; python_version=='3.6' and platform_machine!='aarch64' and platform_system!='AIX'
+    numpy==1.14.5; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX'
+    numpy==1.17.3; python_version=='3.8' and platform_machine!='aarch64'
     numpy==1.19.3; python_version=='3.9'
+
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions
     # to be used and allows wheels to be used as soon as they


### PR DESCRIPTION
Downloads for:
- https://pypi.org/project/numpy/1.18.5/#files (no aarch64)
- https://pypi.org/project/numpy/1.19.0/#files (aarch64)

xref:
- https://github.com/scikit-learn/scikit-learn/pull/18782#issuecomment-723464240
- https://github.com/scikit-learn/scikit-learn/pull/18761 see: https://github.com/scikit-learn/scikit-learn/pull/18761/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711