### PR TITLE
Update for pypy3.7 wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,9 +43,7 @@ install_requires =
     numpy==1.19.3; python_version=='3.9' and platform_python_implementation != 'PyPy'
 
     numpy==1.19.0; python_version=='3.6' and platform_python_implementation=='PyPy'
-    # Change this to 1.20 after it is released since 1.20 will be the first
-    # wheel version on PyPI
-    numpy==1.19.0; python_version=='3.7' and platform_python_implementation=='PyPy'
+    numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions


### PR DESCRIPTION
Binary wheels for pypy3.7 are now available since 1.20 was released