### PR TITLE
Update macOS ARM64 requirement to 1.21.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,10 @@ install_requires =
     numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'
     numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'
 
-    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.20.0
-    numpy==1.20.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
-    numpy==1.20.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
+    # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
+    # (first version with universal2 wheels available)
+    numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
+    numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
 
     # default numpy requirements
     numpy==1.13.3; python_version=='3.5' and platform_machine!='aarch64' and platform_system!='AIX'


### PR DESCRIPTION
This is the first NumPy version with universal2 wheels, and 1.21.0
was just released so we can do the version bump.

This is a follow-up to gh-19 and gh-20 (Cc @kbourgoin)