### PR TITLE
Add 1.21.2 requirement for Python 3.10

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,8 +16,7 @@ jobs:
         - 3.8
         - 3.9
         - pypy3
-        # Uncomment once Numpy builds fine with Python 3.10
-        # - 3.10.0-alpha - 3.10.0
+        - '3.10.0-rc.1 - 3.10.0'
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,6 +46,7 @@ install_requires =
     numpy==1.14.5; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
     numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'
     numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'
+    numpy==1.21.2; python_version=='3.10' and platform_python_implementation != 'PyPy'
 
     numpy==1.19.0; python_version=='3.6' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_python_implementation=='PyPy'
@@ -54,5 +55,5 @@ install_requires =
     # we specify an unpinned Numpy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    numpy; python_version>='3.10'
+    numpy; python_version>='3.11'
     numpy; python_version>='3.8' and platform_python_implementation=='PyPy'


### PR DESCRIPTION
There are now Linux `x86_64` and aarch64 wheels up for 1.21.2,
and the sdist should work for other platforms (wheels will follow,
some infra issues to resolve first - see
https://github.com/MacPython/numpy-wheels/issues/116)