### PR TITLE
Remove conflicting requirements for s390x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ install_requires =
     numpy==1.13.3; python_version=='3.5' and platform_machine!='aarch64' and platform_system!='AIX'
     numpy==1.13.3; python_version=='3.6' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
     numpy==1.14.5; python_version=='3.7' and platform_machine!='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
-    numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='s390x' and platform_python_implementation != 'PyPy'
     numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.4 on all platforms (see gh-28)


### PR DESCRIPTION
The conflicting requirements fail immediately when copying these specifications directly in a requirements file.
However, when processed through `pip install oldest-support-numpy`, pip confusingly installs the two Numpy versions one after the other... (and keeps the wrong one :-/)