### PR TITLE
Resolve conflict with pypy aarch64

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -29,10 +29,10 @@ install_requires =
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2 (For Python 3.5: support
     # was dropped in 1.19 so numpy 1.18.5 can be built from source instead).
-    numpy==1.18.5; python_version=='3.5' and platform_machine=='aarch64'
-    numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64'
-    numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64'
-    numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64'
+    numpy==1.18.5; python_version=='3.5' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.19.2; python_version=='3.6' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
     # (first version with universal2 wheels available)

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -48,7 +48,7 @@ def test_has_at_most_one_pinned_dependency(
         if platform_python_implementation == "PyPy":
             pytest.skip("AIX and PyPy are mutually exclusive.")
 
-    if platform_python_implementation == "PyPy" and (platform_machine != "x86_64"):
+    if platform_python_implementation == "PyPy" and (platform_machine not in ["x86_64", "aarch64"]):
         pytest.skip(f"PyPy is not supported on {platform_machine}.")
 
     environment = {


### PR DESCRIPTION
The conflicting requirements fail immediately when install oldest-supported-numpy with pypy aarch64.
```
oldest-supported-numpy 0.14 depends on numpy==1.19.2; python_version == "3.7" and platform_machine == "aarch64"
oldest-supported-numpy 0.14 depends on numpy==1.20.0; python_version == "3.7" and platform_python_implementation == "PyPy"
```
We can use below cmd to make sure there are only **cpython** support for aarch64, but **pypy** not supported yet.

`curl https://pypi.org/pypi/numpy/json | jq | grep filename | grep whl | grep aarch64`
<details>
<summary>Results</summary>

```
        "filename": "numpy-1.19.0-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0rc1-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0rc1-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0rc1-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0rc2-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0rc2-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.0rc2-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.1-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.1-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.1-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.2-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.2-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.3-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.3-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.3-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.3-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.4-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.4-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.4-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.4-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.5-cp36-cp36m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.5-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.5-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.19.5-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0rc1-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0rc1-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0rc1-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0rc2-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0rc2-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.0rc2-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.1-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.1-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.1-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.2-cp37-cp37m-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.2-cp38-cp38-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.2-cp39-cp39-manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.20.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0rc1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0rc1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0rc1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0rc2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0rc2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.0rc2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.21.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc3-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
        "filename": "numpy-1.22.0rc3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
      "filename": "numpy-1.21.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
      "filename": "numpy-1.21.5-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
      "filename": "numpy-1.21.5-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
      "filename": "numpy-1.21.5-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
```

</details>

After this patch, the aarch64 can be installed directly.

Closes: #39