### PR TITLE
x86 windows wheels were only added from 1.22.3

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,9 @@ install_requires =
     numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.4 on all platforms (see gh-28)
-    numpy==1.21.4; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.21.4; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy' and (platform_system!='Windows' or platform_machine!='x86')
+    # x86 windows wheels were only added from 1.22.3
+    numpy==1.22.3; python_version=='3.10' and platform_machine=='x86' and platform_python_implementation != 'PyPy' and platform_system=='Windows'
 
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -31,7 +31,7 @@ def get_package_dependencies() -> list[Requirement]:
 
 # The ordering of these markers is important, and is used in test names.
 # The tests, when run, look like: PyPy-3.6-Linux-aarch64` (bottom-first)
-@pytest.mark.parametrize("platform_machine", ["x86_64", "aarch64", "s390x", "arm64", "loongarch64"])
+@pytest.mark.parametrize("platform_machine", ["x86", "x86_64", "aarch64", "s390x", "arm64", "loongarch64"])
 @pytest.mark.parametrize("platform_system", ["Linux", "Windows", "Darwin", "AIX"])
 @pytest.mark.parametrize("python_version", ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11"])
 @pytest.mark.parametrize("platform_python_implementation", ["CPython", "PyPy"])


### PR DESCRIPTION
If you look at the versions of numpy: [1.21.4](https://pypi.org/project/numpy/1.21.4/#files), [1.21.5](https://pypi.org/project/numpy/1.21.5/#files), [1.22.0](https://pypi.org/project/numpy/1.22.0/#files), [1.22.1](https://pypi.org/project/numpy/1.22.1/#files), [1.22.2](https://pypi.org/project/numpy/1.22.2/#files), [1.22.3](https://pypi.org/project/numpy/1.22.3/#files), Windows x86 wheels for python 3.10 was only added from 1.22.3. See https://github.com/numpy/numpy/issues/20320#issuecomment-1064284778= for more info on that.