### PR TITLE
Add individiual runtime tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,50 @@ name: Basic tests
 on: [push, pull_request]
 
 jobs:
-  test:
+  test_pins:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
       - run: pip install -r tests/requirements.txt
-      - run: pytest
+      - run: pytest -k test_has_at_most_one_pinned_dependency
+
+  test_install:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
+        python: [ '3.6', '3.7', '3.8', '3.9', '3.10' ]
+        arch: [ 'x64', 'x86' ]
+        qemu: [ 'yes', 'no' ]
+        exclude:
+          - os: macos-latest
+            arch: x86
+          - os: ubuntu-latest
+            arch: x86
+          - os: windows-latest
+            qemu: yes
+          - os: macos-latest
+            qemu: yes
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python }}
+          architecture: ${{ matrix.arch }}
+
+      - name: Set up QEMU
+        if: ${{ matrix.qemu == 'yes' }}
+        uses: docker/setup-qemu-action@v1.2.0
+
+      - name: Install oldest Numpy
+        run: pip install . --only-binary numpy
+
+      - name: Install test dependencies
+        run: pip install -r tests/requirements.txt
+
+      - name: Test valid numpy installed
+        run: pytest -k test_valid_numpy_is_installed

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,9 @@ jobs:
             qemu: yes
           - os: macos-latest
             qemu: yes
+          - os: windows-latest
+            python: '3.10'
+            arch: x86
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,9 +53,7 @@ install_requires =
     numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.4 on all platforms (see gh-28)
-    numpy==1.21.4; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy' and (platform_system!='Windows' or platform_machine!='x86')
-    # x86 windows wheels were only added from 1.22.3
-    numpy==1.22.3; python_version=='3.10' and platform_machine=='x86' and platform_python_implementation != 'PyPy' and platform_system=='Windows'
+    numpy==1.21.4; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
 
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -3,8 +3,9 @@
 
 import configparser
 import pprint
-from functools import cache
+from functools import lru_cache
 from pathlib import Path
+from typing import List
 
 import pytest
 from packaging.requirements import Requirement
@@ -16,8 +17,8 @@ def is_pinned(requirement: Requirement) -> bool:
     return "==" in str(requirement.specifier)
 
 
-@cache
-def get_package_dependencies() -> list[Requirement]:
+@lru_cache(maxsize=None)
+def get_package_dependencies() -> List[Requirement]:
     """A cached reader for getting dependencies of this package."""
     parser = configparser.ConfigParser()
     parser.read(SETUP_CFG_FILE)
@@ -71,3 +72,17 @@ def test_has_at_most_one_pinned_dependency(
     assert (
         len(filtered_requirements) <= 1
     ), f"Expected no more than one pin.\n{pprint.pformat(environment)}"
+
+
+def test_valid_numpy_is_installed():
+    filtered_requirements = []
+    for req in get_package_dependencies():
+        if req.marker.evaluate():
+            filtered_requirements.append(req)
+
+    assert (len(filtered_requirements) == 1), "Expected exactly one pin."
+
+    item, = filtered_requirements[0].specifier
+
+    import numpy
+    assert item.version == numpy.__version__


### PR DESCRIPTION
This add individual runtime test to see that numpy is properly installed on ubuntu/windows/mac for cpython. It tests 3.6-3.10 (3.5 was too old to test...).

I'm adding it because https://github.com/scipy/oldest-supported-numpy/pull/44 was incorrect. `platform_machine` tests the machine it runs on, not the installed python bitness. This is commented on here: https://github.com/pypa/pipenv/issues/2397#issuecomment-399416741= that this was a mistake when originally specified.

The tests I added show this failure.

Where it leaves us is that there's no way to differentiate 32 bit from 64 bit. So that leaves the original issue of that PR and #45. I'm not sure if we should just blindly increase the minimum numpy version for both arches for Windows to `1.22.3`?