### PR TITLE
Add py37 support for arm64

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ install_requires =
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
     # (first version with universal2 wheels available)
+    numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin'
     numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
     numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
 
@@ -48,7 +49,7 @@ install_requires =
     # default numpy requirements
     numpy==1.13.3; python_version=='3.5' and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX'
     numpy==1.13.3; python_version=='3.6' and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
-    numpy==1.14.5; python_version=='3.7' and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
+    numpy==1.14.5; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
     numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='s390x' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
     numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,


### PR DESCRIPTION
Would allow installation of pandas and related libraries to work successfully on Mac M1 Pro processors using Python 3.7. 
Unlikely combination, but we unfortunately need it for the time being.

Tested using python 3.7.13 and pandas 1.3.5, wheels built successfully.