### PR TITLE
simplify condition for platform_machine

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,11 +49,11 @@ install_requires =
     numpy==1.22.2; platform_machine=='loongarch64'
 
     # default numpy requirements
-    numpy==1.13.3; python_version=='3.5' and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX'
-    numpy==1.13.3; python_version=='3.6' and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
-    numpy==1.14.5; python_version=='3.7' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
-    numpy==1.17.3; python_version=='3.8' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='aarch64' and platform_machine!='s390x' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
-    numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.13.3; python_version=='3.5' and platform_machine not in 'aarch64|loongarch64' and platform_system!='AIX'
+    numpy==1.13.3; python_version=='3.6' and platform_machine not in 'aarch64|loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
+    numpy==1.14.5; python_version=='3.7' and platform_machine not in 'arm64|aarch64|loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
+    numpy==1.17.3; python_version=='3.8' and platform_machine not in 'arm64|aarch64|s390x|loongarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.19.3; python_version=='3.9' and platform_machine not in 'arm64|loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.6 on all platforms (see gh-28 and gh-45)
     numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'


### PR DESCRIPTION
From discussion [here](https://github.com/scipy/scipy/pull/16287), CC @rgommers 

We can replace the direct negation of `platform_machine=='arm64' and platform_system=='Darwin'` above with only `platform_machine not in ('arm64')` because there are no machines that satisfy arm64+non-Darwin.