### PR TITLE
add pypy38

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ install_requires =
 
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
+    numpy==1.22.0; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,4 +65,4 @@ install_requires =
     # to be used and allows wheels to be used as soon as they
     # become available.
     numpy; python_version>='3.11'
-    numpy; python_version>='3.8' and platform_python_implementation=='PyPy'
+    numpy; python_version>='3.9' and platform_python_implementation=='PyPy'


### PR DESCRIPTION
Numpy is publishing 3.8 wheels since [1.22.0](https://github.com/numpy/numpy/releases/tag/v1.22.0)