### PR TITLE
Use Numpy 1.22.2 instead of 1.22.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -6,7 +6,7 @@ author = Thomas Robitaille
 author_email = thomas.robitaille@gmail.com
 license = BSD
 url = https://github.com/scipy/oldest-supported-numpy
-version = 2022.5.27
+version = 2022.5.28
 
 # The Numpy pinnings below have been adapted from those in the
 # SciPy package, which is released under a 3-clause BSD license:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,8 @@ install_requires =
     numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'
 
     # loongarch64 requires numpy>=1.22.0
+    # Note that 1.22.0 broke support for using the Python limited C API
+    # (https://github.com/numpy/numpy/pull/20818), so we use 1.22.2 instead
     numpy==1.22.2; platform_machine=='loongarch64'
 
     # default numpy requirements

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ install_requires =
     numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'
 
     # loongarch64 requires numpy>=1.22.0
-    numpy==1.22.0; platform_machine=='loongarch64'
+    numpy==1.22.2; platform_machine=='loongarch64'
 
     # default numpy requirements
     numpy==1.13.3; python_version=='3.5' and platform_machine!='aarch64' and platform_machine!='loongarch64' and platform_system!='AIX'
@@ -58,7 +58,7 @@ install_requires =
 
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
-    numpy==1.22.0; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
+    numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions


### PR DESCRIPTION
Numpy 1.22.0 had a regression that prevented building packages against the Python limited C API, that was fixed in Numpy 1.22.2. See numpy/numpy#20818.

This is causes build failures for my Astropy affiliated package (https://git.ligo.org/lscsoft/ligo.skymap), which like many Astropy affiliated package, depends on oldest-supported-numpy.