### PR TITLE
Use Numpy 1.22.2 instead of 1.21.0--1.22.1

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,15 +36,18 @@ install_requires =
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
     # (first version with universal2 wheels available)
+    # Note that 1.21.0 broke support for using the Python limited C API
+    # (https://github.com/numpy/numpy/pull/20818), so we use 1.22.2 instead
+    # where available
     numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin'
-    numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
-    numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
+    numpy==1.22.2; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
+    numpy==1.22.2; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
 
     # Python 3.8 on s390x requires at least 1.17.5, see gh-29
     numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'
 
     # loongarch64 requires numpy>=1.22.0
-    # Note that 1.22.0 broke support for using the Python limited C API
+    # Note that 1.21.0 broke support for using the Python limited C API
     # (https://github.com/numpy/numpy/pull/20818), so we use 1.22.2 instead
     numpy==1.22.2; platform_machine=='loongarch64'
 
@@ -56,7 +59,9 @@ install_requires =
     numpy==1.19.3; python_version=='3.9' and (platform_machine!='arm64' or platform_system!='Darwin') and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.6 on all platforms (see gh-28 and gh-45)
-    numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
+    # Note that 1.21.0 broke support for using the Python limited C API
+    # (https://github.com/numpy/numpy/pull/20818), so we use 1.22.2 instead
+    numpy==1.22.2; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'
 
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'


### PR DESCRIPTION
This is a follow up to #58. The Numpy regression fixed in numpy/numpy#20818 was introduced in Numpy 1.21.0, not 1.22.0. My mistake. Sorry!