### PR TITLE
Edit code comment: universal2 -> arm64 wheels on macOS

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
-    # (first version with universal2 wheels available)
+    # (first version with arm64 wheels available)
     numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin'
     numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
     numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'


### PR DESCRIPTION
NumPy 1.21.0 doesn't have `universal2` wheels, and either way those are irrelevant/useless: we need `arm64` wheels.