### PR TITLE
support the IBMi platform

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,9 @@ install_requires =
     numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
 
+    #IBM i requires fixes contained in numpy 1.23.3.
+    numpy==1.23.3; python_version=='3.9' and platform_system=='OS400'
+
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2 (For Python 3.5: support
     # was dropped in 1.19 so numpy 1.18.5 can be built from source instead).

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,7 +56,7 @@ install_requires =
     numpy==1.13.3; python_version=='3.6' and platform_machine not in 'aarch64|loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
     numpy==1.14.5; python_version=='3.7' and platform_machine not in 'arm64|aarch64|loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
     numpy==1.17.3; python_version=='3.8' and platform_machine not in 'arm64|aarch64|s390x|loongarch64' and platform_python_implementation != 'PyPy'
-    numpy==1.19.3; python_version=='3.9' and platform_machine not in 'arm64|loongarch64' and platform_python_implementation != 'PyPy'
+    numpy==1.19.3; python_version=='3.9' and platform_system not in 'OS400' and platform_machine not in 'arm64|loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.6 on all platforms (see gh-28 and gh-45)
     numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64' and platform_python_implementation != 'PyPy'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,9 @@ install_requires =
     numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
     numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
 
-    #IBM i requires fixes contained in numpy 1.23.3.
+    # IBM i requires fixes contained in numpy 1.23.3. Only Python 3.6 and 3.9
+    # are supported on IBM i system, so we're ignoring other Python versions here
+    # for simplicity (see gh-66).
     numpy==1.23.3; python_version=='3.9' and platform_system=='OS400'
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -33,7 +33,7 @@ def get_package_dependencies() -> List[Requirement]:
 # The ordering of these markers is important, and is used in test names.
 # The tests, when run, look like: PyPy-3.6-Linux-aarch64` (bottom-first)
 @pytest.mark.parametrize("platform_machine", ["x86", "x86_64", "aarch64", "s390x", "arm64", "loongarch64"])
-@pytest.mark.parametrize("platform_system", ["Linux", "Windows", "Darwin", "AIX"])
+@pytest.mark.parametrize("platform_system", ["Linux", "Windows", "Darwin", "AIX", "OS400"])
 @pytest.mark.parametrize("python_version", ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"])
 @pytest.mark.parametrize("platform_python_implementation", ["CPython", "PyPy"])
 def test_has_at_most_one_pinned_dependency(

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -43,14 +43,11 @@ def test_has_at_most_one_pinned_dependency(
     platform_python_implementation,
 ):
     # These are known to be platforms that are not valid / possible at this time.
-    if platform_system == "AIX":
+    if platform_system in ("AIX", "OS400"):
         if platform_machine in ["aarch64", "loongarch64"]:
-            pytest.skip("AIX and aarch64 are mutually exclusive.")
+            pytest.skip(f"{platform_system} and {platform_machine} are mutually exclusive.")
         if platform_python_implementation == "PyPy":
-            pytest.skip("AIX and PyPy are mutually exclusive.")
-
-    if platform_system == "OS400":
-        pytest.skip("Skip this test for OS400.")
+            pytest.skip(f"{platform_system} and PyPy are mutually exclusive.")
 
     if platform_python_implementation == "PyPy" and (platform_machine not in ["x86_64", "aarch64"]):
         pytest.skip(f"PyPy is not supported on {platform_machine}.")

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -49,6 +49,9 @@ def test_has_at_most_one_pinned_dependency(
         if platform_python_implementation == "PyPy":
             pytest.skip("AIX and PyPy are mutually exclusive.")
 
+    if platform_system == "OS400":
+        pytest.skip("Skip this test for OS400.")
+
     if platform_python_implementation == "PyPy" and (platform_machine not in ["x86_64", "aarch64"]):
         pytest.skip(f"PyPy is not supported on {platform_machine}.")
 


### PR DESCRIPTION
I am adding the oldest Numpy version for IBM i , which include our fixes for IBM i platform. Please help to review. thanks.

@rgommers need your help again. thx.