### PR TITLE
Fix incompatible requirements

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
-        python: [ '3.6', '3.7', '3.8', '3.9', '3.10', '3.11-dev' ]
+        python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: [ 'x64', 'x86' ]
         exclude:
           - os: macos-latest

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,9 @@ install_requires =
     #       tests for this package.
 
     # AIX requires fixes contained in numpy 1.16
-    numpy==1.16.0; python_version=='3.5' and platform_system=='AIX'
-    numpy==1.16.0; python_version=='3.6' and platform_system=='AIX'
-    numpy==1.16.0; python_version=='3.7' and platform_system=='AIX'
+    numpy==1.16.0; python_version=='3.5' and platform_system=='AIX' and (platform_machine!='aarch64' or platform_python_implementation == 'PyPy')
+    numpy==1.16.0; python_version=='3.6' and platform_system=='AIX' and (platform_machine=='loongarch64' or platform_machine!='aarch64' and platform_python_implementation != 'PyPy')
+    numpy==1.16.0; python_version=='3.7' and platform_system=='AIX' and (platform_machine=='loongarch64' or platform_machine!='aarch64' and platform_python_implementation != 'PyPy')
 
     # IBM i requires fixes contained in numpy 1.23.3. Only Python 3.6 and 3.9
     # are supported on IBM i system, so we're ignoring other Python versions here
@@ -42,8 +42,8 @@ install_requires =
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
     # (first version with arm64 wheels available)
     numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin'
-    numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin'
-    numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
+    numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation != 'PyPy'
+    numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_system!='OS400'
 
     # Python 3.8 on s390x requires at least 1.17.5, see gh-29
     numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'
@@ -51,7 +51,7 @@ install_requires =
     # loongarch64 requires numpy>=1.22.0
     # Note that 1.22.0 broke support for using the Python limited C API
     # (https://github.com/numpy/numpy/pull/20818), so we use 1.22.2 instead
-    numpy==1.22.2; platform_machine=='loongarch64' and python_version<'3.11'
+    numpy==1.22.2; platform_machine=='loongarch64' and python_version>='3.8' and python_version<'3.11' and platform_system!='OS400'
 
     # default numpy requirements
     numpy==1.13.3; python_version=='3.5' and platform_machine not in 'aarch64|loongarch64' and platform_system!='AIX'
@@ -66,7 +66,7 @@ install_requires =
 
     # PyPy requirements
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
-    numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
+    numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy' and (platform_machine!='arm64' or platform_system!='Darwin')
     numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
 
     # For Python versions which aren't yet officially supported,


### PR DESCRIPTION
Resolves: #70 

For each pair of incompatible requirements, I assumed that the higher required numpy is the correct one. Thus, I added the inverted marker of this requirement to the marker of the other requirement. I repeated this process (and simplified the resulting markers if possible) until all conflicts detected by Poetry were resolved.

Of course, there are other options to eliminate the incompatible requirements, so someone with more expertise in this topic should check carefully if my changes make sense.