### PR TITLE
MNT: add pins for pypy39

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,12 +50,12 @@ install_requires =
     # formulate a separate requirement just for win-arm64
     numpy==1.14.5; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Windows' and platform_python_implementation != 'PyPy'
     numpy==1.17.3; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Windows' and platform_python_implementation != 'PyPy'
-    numpy==1.19.3; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Windows'
+    numpy==1.19.3; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Windows' and platform_python_implementation != 'PyPy'
 
     # default numpy requirements
     numpy==1.14.5; python_version=='3.7' and platform_machine not in 'arm64|aarch64|loongarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
     numpy==1.17.3; python_version=='3.8' and platform_machine not in 'arm64|aarch64|s390x|loongarch64' and platform_python_implementation != 'PyPy'
-    numpy==1.19.3; python_version=='3.9' and platform_system not in 'OS400' and platform_machine not in 'arm64|loongarch64'
+    numpy==1.19.3; python_version=='3.9' and platform_system not in 'OS400' and platform_machine not in 'arm64|loongarch64' and platform_python_implementation != 'PyPy'
     # Note that 1.21.3 was the first version with a complete set of 3.10 wheels,
     # however macOS was broken and it's safe to build against 1.21.6 on all platforms (see gh-28 and gh-45)
     numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64'
@@ -65,6 +65,7 @@ install_requires =
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
+    numpy==1.25.0; python_version=='3.9' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     # (first version with arm64 wheels available)
     numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
     numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
-    numpy==1.22.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
+    numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
 
     # Python 3.8 on s390x requires at least 1.17.5, see gh-29
     numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     # IBM i requires fixes contained in numpy 1.23.3. Only Python 3.6 and 3.9
     # are supported on IBM i system, so we're ignoring other Python versions here
     # for simplicity (see gh-66).
-    numpy==1.23.3; python_version=='3.9' and platform_system=='OS400' and platform_machine!='loongarch64'
+    numpy==1.23.3; python_version=='3.9' and platform_system=='OS400' and platform_machine!='loongarch64' and platform_python_implementation!='PyPy'
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
     # wheels require fixes contained in numpy 1.19.2
@@ -35,7 +35,7 @@ install_requires =
     # (first version with arm64 wheels available)
     numpy==1.21.0; python_version=='3.7' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
     numpy==1.21.0; python_version=='3.8' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
-    numpy==1.21.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin'
+    numpy==1.22.0; python_version=='3.9' and platform_machine=='arm64' and platform_system=='Darwin' and platform_python_implementation!='PyPy'
 
     # Python 3.8 on s390x requires at least 1.17.5, see gh-29
     numpy==1.17.5; python_version=='3.8' and platform_machine=='s390x' and platform_python_implementation != 'PyPy'
@@ -43,7 +43,7 @@ install_requires =
     # loongarch64 requires numpy>=1.22.0
     # Note that 1.22.0 broke support for using the Python limited C API
     # (https://github.com/numpy/numpy/pull/20818), so we use 1.22.2 instead
-    numpy==1.22.2; platform_machine=='loongarch64' and python_version>='3.8' and python_version<'3.11'
+    numpy==1.22.2; platform_machine=='loongarch64' and python_version>='3.8' and python_version<'3.11' and platform_python_implementation!='PyPy'
 
     # win-arm64; in the absence of information to the contrary, we want to use the default pins below;
     # however, these are excluded due to `platform_machine not in 'arm64|...'`, so it's easier to
@@ -65,7 +65,7 @@ install_requires =
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.20.0; python_version=='3.7' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
     numpy==1.22.2; python_version=='3.8' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
-    numpy==1.25.0; python_version=='3.9' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
+    numpy==1.25.0; python_version=='3.9' and platform_python_implementation=='PyPy'
 
     # For Python versions which aren't yet officially supported,
     # we specify an unpinned Numpy which allows source distributions


### PR DESCRIPTION
Got bit by this in Matplotlib CI where it was selecting 1.19.3 for pypy39.