### PR TITLE
Update after NumPy 1.26.0 release

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ install_requires =
     # however macOS was broken and it's safe to build against 1.21.6 on all platforms (see gh-28 and gh-45)
     numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64'
     numpy==1.23.2; python_version=='3.11'
+    numpy==1.26.1; python_version=='3.12'
 
     # PyPy requirements
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'
@@ -71,4 +72,4 @@ install_requires =
     # we specify an unpinned Numpy which allows source distributions
     # to be used and allows wheels to be used as soon as they
     # become available.
-    numpy; python_version>='3.12'
+    numpy; python_version>='3.13'

--- a/tests/test_dependencies.py
+++ b/tests/test_dependencies.py
@@ -106,7 +106,7 @@ def test_has_at_most_one_pinned_dependency(
     # for valid combinations, we test more strictly: expect exactly zero or one pins
     if valid:
         # we only expect a pin for released python versions
-        expect_pin = False if (python_version == "3.12") else expect_pin
+        expect_pin = False if (python_version == "3.13") else expect_pin
         log_msg = "Expected " + ("exactly one pin" if expect_pin else "no pins")
         assert (
             len(filtered_requirements) == int(expect_pin)


### PR DESCRIPTION
- NumPy 1.26.0 adds support for Python 3.12.
- NumPy 1.25.0 has Python 3.9 compatible wheels for PyPy


Looks like the PyPy addition is also taken care of in #78, so that might be a conflict.