### PR TITLE
Fix GitHub dependency graph

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,2 @@
 from setuptools import setup
-setup()
+setup(name="oldest-supported-numpy")  # need by GitHub dependency graph


### PR DESCRIPTION
This fixes a bug with GitHub's dependency graph, which is [currently empty](https://github.com/scipy/oldest-supported-numpy/network/dependents).

More on the issue here: https://github.com/orgs/community/discussions/6456