### PR TITLE
Bump default numpy on Python3.12 to 1.26.2

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -60,7 +60,9 @@ install_requires =
     # however macOS was broken and it's safe to build against 1.21.6 on all platforms (see gh-28 and gh-45)
     numpy==1.21.6; python_version=='3.10' and platform_machine!='loongarch64'
     numpy==1.23.2; python_version=='3.11'
-    numpy==1.26.1; python_version=='3.12'
+    # numpy 1.26 before 1.26.2 enforced the presence of a blas library
+    # when building from source, e.g. on i686 ( https://github.com/numpy/numpy/issues/24703 )
+    numpy==1.26.2; python_version=='3.12'
 
     # PyPy requirements
     numpy==1.19.0; python_version=='3.6' and platform_machine!='loongarch64' and platform_python_implementation=='PyPy'


### PR DESCRIPTION
numpy 1.26 before 1.26.2 enforced the presence of a blas library when building from source, e.g. on i686 ( https://github.com/numpy/numpy/issues/24703 )

I have encountered this at: https://github.com/bxlab/bx-python/actions/runs/7180855870/job/19554009744#step:6:1827