### PR TITLE
update to 1.19.3 for python3.8 in aarch64 to limit cython<3.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -27,9 +27,9 @@ install_requires =
     numpy==1.23.3; python_version=='3.9' and platform_system=='OS400' and platform_machine!='loongarch64' and platform_python_implementation!='PyPy'
 
     # numpy 1.19 was the first minor release to provide aarch64 wheels, but
-    # wheels require fixes contained in numpy 1.19.2
-    numpy==1.19.2; python_version=='3.7' and platform_machine=='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
-    numpy==1.19.2; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
+    # wheels require fixes contained in numpy 1.19.3
+    numpy==1.19.3; python_version=='3.7' and platform_machine=='aarch64' and platform_system!='AIX' and platform_python_implementation != 'PyPy'
+    numpy==1.19.3; python_version=='3.8' and platform_machine=='aarch64' and platform_python_implementation != 'PyPy'
 
     # arm64 on Darwin supports Python 3.8 and above requires numpy>=1.21.0
     # (first version with arm64 wheels available)


### PR DESCRIPTION
proposed fix for #80 

as mentioned in https://github.com/scipy/oldest-supported-numpy/issues/80#issuecomment-1860363010 I do not know all the implication of updating a `patch` version so please feel free to close this PR if it's not possible to update numpy to `1.19.3`