### PR TITLE
DOC: add instructions to deprecation notice

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,13 +18,13 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ 'windows-latest', 'macos-latest', 'ubuntu-latest' ]
+        os: [ 'windows-2022', 'macos-13', 'ubuntu-24.04' ]
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: [ 'x64', 'x86' ]
         exclude:
-          - os: macos-latest
+          - os: macos-13
             arch: x86
-          - os: ubuntu-latest
+          - os: ubuntu-24.04
             arch: x86
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'windows-2022', 'macos-13', 'ubuntu-20.04' ]
+        os: [ 'windows-2022', 'macos-13', 'ubuntu-22.04' ]
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: [ 'x64', 'x86' ]
         exclude:
           - os: macos-13
             arch: x86
-          - os: ubuntu-24.04
+          - os: ubuntu-22.04
             arch: x86
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,9 +16,8 @@ jobs:
   test_install:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
       matrix:
-        os: [ 'windows-2022', 'macos-13', 'ubuntu-24.04' ]
+        os: [ 'windows-2022', 'macos-13', 'ubuntu-22.04' ]
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: [ 'x64', 'x86' ]
         exclude:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ 'windows-2022', 'macos-13', 'ubuntu-22.04' ]
+        os: [ 'windows-2022', 'macos-13', 'ubuntu-20.04' ]
         python: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
         arch: [ 'x64', 'x86' ]
         exclude:

--- a/README.rst
+++ b/README.rst
@@ -22,17 +22,17 @@ directly, according to the guidance given in
 .. code:: toml
 
     [build-system]
-    requires = ["numpy>=1.25,<3"]
+    requires = ["numpy>=2.0,<3"]
 
-Compiling backward-compatible wheels using NumPy 1.x for older Python
-versions can still be done using this package.
+Python 3.13 is supported as of NumPy 2.1. For older Python versions
+this package can still be used to compile against NumPy 1.xx.
 
 .. code:: toml
 
     [build-system]
     requires = [
         "oldest-supported-numpy; python_version<='3.8'",
-        "numpy>=1.25,<3; python_version>'3.8'",
+        "numpy>=1.25,<2; python_version>'3.8'",
     ]
 
 About

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,23 @@ NumPy 1.xx and 2.0.
 
 All users should migrate to expressing a build dependency on ``numpy``
 directly, according to the guidance given in
-`Adding a dependency on NumPy <https://numpy.org/devdocs/dev/depending_on_numpy.html#adding-a-dependency-on-numpy>`__.
+`Adding a dependency on NumPy <https://numpy.org/doc/2.1/dev/depending_on_numpy.html#build-time-dependency>`__.
 
+.. code:: toml
+
+    [build-system]
+    requires = ["numpy>=1.25,<3"]
+
+Compiling backward-compatible wheels using NumPy 1.x for older Python
+versions can still be done using this package.
+
+.. code:: toml
+
+    [build-system]
+    requires = [
+        "oldest-supported-numpy; python_version<='3.8'",
+        "numpy>=1.25,<3; python_version>'3.8'",
+    ]
 
 About
 -----


### PR DESCRIPTION
- python 3.7 - 3.12 can be supported with numpy v1 build-system
- python 3.9 - 3.13 can be supported with numpy v2 build-system

took me a while to figure this one out, particularly in order to get musllinux_aarch64 working on cp39 in https://github.com/vaexio/vaex/pull/2434

closes #85 and closes #75